### PR TITLE
Graph batch response/ request POC

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/Handlers/AuthenticationHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Handlers/AuthenticationHandler.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Graph
 
                 // Authenticate request using AuthenticationProvider
 
-                await AuthenticationProvider.AuthenticateRequestAsync(newRequest);
+                await authProvider.AuthenticateRequestAsync(newRequest);
                 httpResponseMessage = await base.SendAsync(newRequest, cancellationToken);
 
                 retryAttempt++;

--- a/src/Microsoft.Graph/Models/Extensions/BaseBatchItem.cs
+++ b/src/Microsoft.Graph/Models/Extensions/BaseBatchItem.cs
@@ -1,0 +1,24 @@
+﻿namespace Microsoft.Graph
+{
+    using Newtonsoft.Json;
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    public class BaseBatchItem
+    {
+        public BaseBatchItem()
+        {
+            Headers = new Dictionary<string, string>();
+        }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "id", Required = Required.Default)]
+        public int Id { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "body", Required = Required.Default)]
+        public object Body { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "headers", Required = Required.Default)]
+        public Dictionary<string, string> Headers { get; set; }
+    }
+}

--- a/src/Microsoft.Graph/Models/Extensions/BatchRequest.cs
+++ b/src/Microsoft.Graph/Models/Extensions/BatchRequest.cs
@@ -1,0 +1,16 @@
+﻿namespace Microsoft.Graph
+{
+    using Newtonsoft.Json;
+    using System.Collections.Generic;
+
+    public class BatchRequest
+    {
+        public BatchRequest()
+        {
+            RequestItems = new List<BatchRequestItem>();
+        }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "requests", Required = Required.Default)]
+        public ICollection<BatchRequestItem> RequestItems { get; set; }
+    }
+}

--- a/src/Microsoft.Graph/Models/Extensions/BatchRequestItem.cs
+++ b/src/Microsoft.Graph/Models/Extensions/BatchRequestItem.cs
@@ -1,0 +1,18 @@
+﻿using System;
+namespace Microsoft.Graph
+{
+    using Newtonsoft.Json;
+    using System.Collections.Generic;
+    using System.Text;
+    public class BatchRequestItem : BaseBatchItem
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "url", Required = Required.Default)]
+        public string Url { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "method", Required = Required.Default)]
+        public string Method { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "dependsOn", Required = Required.Default)]
+        public int[] DependsOn { get; set; }
+    }
+}

--- a/src/Microsoft.Graph/Models/Extensions/BatchResponse.cs
+++ b/src/Microsoft.Graph/Models/Extensions/BatchResponse.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Graph
+{
+    public class BatchResponse
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "responses", Required = Required.Default)]
+        public ICollection<BatchResponseItem> Responses { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.nextLink", Required = Required.Default)]
+        public string NextLink { get; set; }
+    }
+}

--- a/src/Microsoft.Graph/Models/Extensions/BatchResponseItem.cs
+++ b/src/Microsoft.Graph/Models/Extensions/BatchResponseItem.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Microsoft.Graph
+{
+    public class BatchResponseItem: BaseBatchItem
+    {
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "status", Required = Required.Default)]
+        public int Status { get; set; }
+    }
+}

--- a/src/Microsoft.Graph/Requests/Extensions/BatchRequestBuilder.cs
+++ b/src/Microsoft.Graph/Requests/Extensions/BatchRequestBuilder.cs
@@ -1,0 +1,31 @@
+﻿namespace Microsoft.Graph
+{
+    using Newtonsoft.Json;
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class BatchRequestBuilder
+    {
+        private IBaseClient _client;
+
+        public BatchRequestBuilder(IBaseClient client)
+        {
+            _client = client;
+        }
+
+        public async Task<BatchResponse> PostAsync(BatchRequestContext batchRequest)
+        {
+            BaseRequest request = new BaseRequest(_client.BaseUrl + "/$batch", _client);
+            request.ContentType = "application/json";
+            request.Headers.Add(new HeaderOption("Accept", "application/json"));
+            request.Method = "POST";
+
+            return await request
+                .SendAsync<BatchResponse>(batchRequest.BatchRequest, CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Microsoft.Graph/Requests/Extensions/BatchRequestContext.cs
+++ b/src/Microsoft.Graph/Requests/Extensions/BatchRequestContext.cs
@@ -1,0 +1,24 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Graph
+{
+    public class BatchRequestContext
+    {
+        public BatchRequest BatchRequest { get; private set; }
+        public BatchRequestContext()
+        {
+            BatchRequest = new BatchRequest();
+        }
+
+        public void AddRequest(int id, BatchRequestItem batchRequest, int[] dependsOn)
+        {
+            batchRequest.Id = id;
+            batchRequest.DependsOn = dependsOn;
+
+            BatchRequest.RequestItems.Add(batchRequest);
+        }
+    }
+}

--- a/src/Microsoft.Graph/Requests/Extensions/IBaseRequestExtensions.cs
+++ b/src/Microsoft.Graph/Requests/Extensions/IBaseRequestExtensions.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+
+namespace Microsoft.Graph
+{
+    public static class IBaseRequestExtensions
+    {
+        public static BatchRequestItem BatchCreate<T>(this T baseRequest, object item) where T : IBaseRequest
+        {
+            GetRelativeUrl(baseRequest);
+            return new BatchRequestItem
+            {
+                Body = item,
+                Url = GetRelativeUrl(baseRequest),
+                Headers = new Dictionary<string, string>() { { "Content-Type", "application/json" } },
+                Method = "POST",
+            };
+        }
+
+        public static BatchRequestItem BatchGet<T>(this T baseRequest) where T : IBaseRequest
+        {
+            GetRelativeUrl(baseRequest);
+            return new BatchRequestItem
+            {
+                Url = GetRelativeUrl(baseRequest),
+                Method = "GET"
+            };
+        }
+
+        public static BatchRequestItem BatchDelete<T>(this T baseRequest) where T : IBaseRequest
+        {
+            return new BatchRequestItem
+            {
+                Url = GetRelativeUrl(baseRequest),
+                Method = "DELETE",
+            };
+        }
+
+        public static BatchRequestItem BatchUpdate<T>(this T baseRequest, object item) where T : IBaseRequest
+        {
+            return new BatchRequestItem
+            {
+                Body = item,
+                Url = GetRelativeUrl(baseRequest),
+                Headers = new Dictionary<string, string>() { { "Content-Type", "application/json" } },
+                Method = "PATCH",
+            };
+        }
+
+        private static string GetRelativeUrl(IBaseRequest baseRequest)
+        {
+            string version = "v1.0";
+            if (baseRequest.RequestUrl.Contains("beta"))
+                version = "beta";
+
+            return baseRequest.RequestUrl.Substring(baseRequest.RequestUrl.IndexOf(version) + version.ToCharArray().Length);
+        }
+    }
+}

--- a/src/Microsoft.Graph/Requests/Extensions/IGraphServiceClientExtensions.cs
+++ b/src/Microsoft.Graph/Requests/Extensions/IGraphServiceClientExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Graph
+{
+    public static class IGraphServiceClientExtensions
+    {
+        public static BatchRequestBuilder Batch(this IGraphServiceClient graphServiceClient)
+        {
+            return new BatchRequestBuilder(graphServiceClient);
+        }
+    }
+
+}

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Functional/BatchRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Functional/BatchRequestTests.cs
@@ -1,0 +1,26 @@
+﻿namespace Microsoft.Graph.DotnetCore.Test.Requests.Functional
+{
+    using System;
+    using Xunit;
+    using System.Threading.Tasks;
+    using System.Collections.Generic;
+
+    public class BatchRequestTests : GraphTestBase
+    {
+        [Fact]
+        public async Task BatchRequestPostAsync()
+        {
+            // STEP 1: Get individual request
+            BatchRequestItem request1 = graphClient.Me.Request().BatchGet();
+            BatchRequestItem request2 = graphClient.Me.Messages.Request().BatchGet();
+
+            // STEP 2: Specify dependencies, or lack thereof
+            BatchRequestContext batchRequestContext = new BatchRequestContext();
+            batchRequestContext.AddRequest(1, request1, null);
+            batchRequestContext.AddRequest(2, request2, null);
+
+            // STEP 3: Execute batch request
+            BatchResponse batchResponse = await graphClient.Batch().PostAsync(batchRequestContext);
+        }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Functional/GraphTestBase.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Functional/GraphTestBase.cs
@@ -88,8 +88,8 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Functional
                 responseTask.Wait();
                 string responseContent = responseTask.Result;
                 jResult = JObject.Parse(responseContent);
+                accessToken = (string)jResult["access_token"];
             }
-            accessToken = (string)jResult["access_token"];
 
             if (!String.IsNullOrEmpty(accessToken))
             {


### PR DESCRIPTION
A quick POC to show we can extend Graph Service Client to handle batch requests & responses.

## Proposed Call Structure
``` csharp
// STEP 1: Get individual request
BatchRequestItem request1 = graphClient.Me.Request().BatchGet();
BatchRequestItem request2 = graphClient.Me.Messages.Request().BatchGet();

// STEP 2: Specify dependencies, or lack thereof
BatchRequestContext batchRequestContext = new BatchRequestContext();
batchRequestContext.AddRequest(1, request1, null);
batchRequestContext.AddRequest(2, request2, new int[] { 1 });

// STEP 3: Execute batch request
BatchResponse batchResponse = await graphClient.Batch().PostAsync(batchRequestContext);
```